### PR TITLE
refactor to remove RunningFromWPF

### DIFF
--- a/NetSparkleTestAppWPF/MainWindow.xaml.cs
+++ b/NetSparkleTestAppWPF/MainWindow.xaml.cs
@@ -26,7 +26,6 @@ namespace NetSparkle.TestAppWPF
             string manifestModuleName = System.Reflection.Assembly.GetEntryAssembly().ManifestModule.FullyQualifiedName;
             var icon = System.Drawing.Icon.ExtractAssociatedIcon(manifestModuleName);
             _sparkle = new Sparkle("https://deadpikle.github.io/NetSparkle/files/sample-app/appcast.xml", icon); //, "NetSparkleTestApp.exe");
-            _sparkle.RunningFromWPF = true;
             _sparkle.StartLoop(true, true);
         }
 


### PR DESCRIPTION
- refactor to remove RunningFromWPF
- renamed `CloseWPFSoftware` to `CloseApplication` (and `Async` equivalents), and always run these (if present) to close the application, instead of just when `RunningFromWPF`