### PR TITLE
Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+### Added
+- This changelog
+- `Sparkle` class documentation to the readme
+- Section about how the appcast works to the readme
+
+### Changed
+- Cleaned up and added documentation comments throughout the code
+- Renamed lots of identifiers throughout the project to remove "NetSparkle" (i.e., `NetSparkleAppCast` to `AppCast`, `NetSparkleConfiguration` to `Configuration`, etc.)
+- Renamed property `UseSyncronizedForms` to `ShowsUIOnMainThread` to better represent what it does
+- Renamed events `CloseWPFSoftware` and `CloseWPFSoftwareAsync` to `CloseApplication` and `CloseApplicationAsync`
+    - These events are now always run, if present (instead of only on `RunningFromWPF`)
+    - If one of these events is set, it will be run instead of quitting your app (to allow you a custom quit procedure), so these events should take care of quitting your app.
+- Renamed `DSAVerificator` to `DSAChecker`
+
+### Removed
+- deprecated property `EnableSilentMode`
+- property `RunningFromWPF`
+
+## [0.9.1.1] - 2015-12-03
+### Added
+- `ClearOldInstallers` Action that you can implement on your own to remove old installers. Use this if you download installers to a custom folder and need to erase them later.
+
+### Changed
+- Fixed compilation issue with `EnableSilentMode` (not sure how I never came across this!)
+
+## [0.9.1] - 2015-10-06
+### Added
+- `UpdateSize` to `NetSparkleAppCastItem`, analogous to the `length` field within the `<enclosure>` tag
+- `IsCriticalUpdate` to `NetSparkleAppCastItem`
+    - To use, add `sparkle:criticalUpdate="true"` as an attribute to the `<enclosure>` tag
+    - When any update that the user needs is marked as critical, the skip and remind me later buttons are disabled
+    - When an update is marked as critical, the release notes for that version state that the update is critical
+    - To do something about a critical update in your own software, check `Sparkle.LatestAppCastItems` or `Sparkle.UpdateMarkedCritical` to see if an update in the list of updates that the user needs is critical
+
+## [0.9] - 2017-03-28
+### Added
+- Several more diagnostic messages for debugging on the console
+- New `SilentMode` option to allow for the "normal" update process (`NotSilent`), completely silent updates (`DownloadAndInstall`), or silent downloads that you as the developer initiate the start of the update manually (`DownloadNoInstall`)
+    - `DownloadAndInstall` may be quite jarring to your users if you don't tell them the software is about to quit to restart. Use `AboutToExitForInstallerRun` or `AboutToExitForInstallerRunAsync` to monitor for these events.
+    - For proper `DownloadNoInstall` use, monitor the `DownloadedFileReady` event to know when things are ready. At some later time, call `_sparkle.ShowUpdateNeededUI(true);` to show the software update window. You may want to monitor other events as well to keep your user from performing another update check while a software update is downloading.
+- `TmpDownloadFilePath` to redirect the download location. This should be a folder, not a full path. Note that you still need to manually delete files that are downloaded here.
+
+### Changed
+- Deprecated EnableSilentMode in lieu of SilentMode
+- Stopped the software from redownloading the installer if it already exists on disk (saves bandwidth and time on the user's part)
+    - Note that NetSparkle does not perform resumable downloads in between software instances
+- Fixed potential infinite software update download loop if the software keeps downloading corrupted files (corrupt files or ones that don't pass the DSA check).
+
+[Unreleased]: https://github.com/Deadpikle/NetSparkle/compare/v0.9.1.1...develop
+[0.9.1.1]: https://github.com/Deadpikle/NetSparkle/compare/v0.9.1...v0.9.1.1
+[0.9.1]: https://github.com/Deadpikle/NetSparkle/compare/v0.9...v0.9.1
+[0.9]: https://github.com/Deadpikle/NetSparkle/compare/v0.8.1...v0.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ All notable changes to this project will be documented in this file.
     - Note that NetSparkle does not perform resumable downloads in between software instances
 - Fixed potential infinite software update download loop if the software keeps downloading corrupted files (corrupt files or ones that don't pass the DSA check).
 
-[Unreleased]: https://github.com/Deadpikle/NetSparkle/compare/v0.9.1.1...develop
-[0.9.1.1]: https://github.com/Deadpikle/NetSparkle/compare/v0.9.1...v0.9.1.1
-[0.9.1]: https://github.com/Deadpikle/NetSparkle/compare/v0.9...v0.9.1
-[0.9]: https://github.com/Deadpikle/NetSparkle/compare/v0.8.1...v0.9
+[Unreleased]: https://github.com/Deadpikle/NetSparkle/compare/c5e1e49...develop
+[0.9.1.1]: https://github.com/Deadpikle/NetSparkle/compare/e0f5004...c5e1e49
+[0.9.1]: https://github.com/Deadpikle/NetSparkle/compare/7d679f0...e0f5004
+[0.9]: https://github.com/Deadpikle/NetSparkle/compare/8034ec2...7d679f0

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # NetSparkle
 
-NetSparkle is a C# .NET update checker that allows you to easily download installer files and update your WinForms or C# WPF software. You provide, somewhere on the net, an rss xml file that advertises latest version. You also provide release notes. This library then checks for an update in the background, shows the user the release notes, and offers to download the new installer. The original NetSparkle library can be found [here](https://github.com/dei79/netsparkle).
-
-**Please make sure to check the `develop` branch for the latest updates! It will be the default branch soon.**
+NetSparkle is a C# .NET update checker that allows you to easily download installer files and update your WinForms or C# WPF software. You provide, somewhere on the internet, an XML appcast with version information, along with release notes in Markdown or HTML format. This library then checks for an update in the background, shows the user the release notes, and offers to download the new installer. The original NetSparkle library can be found at [dei79/netsparkle](https://github.com/dei79/netsparkle).
 
 - [Basic Usage](#basic-usage)
 - [Appcast](#appcast)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NetSparkle
 
+All notable changes to this project will be documented in the [changelog](CHANGELOG.md).
+
 NetSparkle is a C# .NET update checker that allows you to easily download installer files and update your WinForms or C# WPF software. You provide, somewhere on the internet, an XML appcast with version information, along with release notes in Markdown or HTML format. This library then checks for an update in the background, shows the user the release notes, and offers to download the new installer. The original NetSparkle library can be found at [dei79/netsparkle](https://github.com/dei79/netsparkle).
 
 - [Basic Usage](#basic-usage)


### PR DESCRIPTION
The format is based on [Keep a CHANGELOG](http://keepachangelog.com/en/0.3.0/).

Each entry is split into up to three sections: Added, Changed, and Removed. This makes it easy to scan because it is consistent, and because it splits out new things from changed and removed things.

One good thing about this format is that it's easy to make a new release. Add significant changes to the Unreleased entry as they are developed. When it's time to release, just change the Unreleased entry to the new version number and add a new Unreleased entry at the top.