### PR TITLE
Don't skip DSA signature check for downloaded file if signature is null

### DIFF
--- a/NetSparkle/DSAChecker.cs
+++ b/NetSparkle/DSAChecker.cs
@@ -42,7 +42,7 @@ namespace NetSparkle
 
             if (string.IsNullOrEmpty(key))
             {
-                // TODO: Loading Ressources don't work
+                // TODO: Loading Resources don't work
                 Stream data = TryGetResourceStream(publicKeyFile);
                 if (data == null)
                     data = TryGetFileResource(publicKeyFile, data);
@@ -100,13 +100,13 @@ namespace NetSparkle
             switch (_securityMode)
             {
                 case SecurityMode.UseIfPossible:
-                    // if we have an dsa key we accept only signatures
+                    // if we have a DSA key we only accept non-null signatures
                     if (PublicKeyExists() && string.IsNullOrEmpty(signature))
                     {
                         result = ValidationResult.Invalid;
                         return false;
                     }
-                    // if we don't have an dsa key we accept all.
+                    // if we don't have an dsa key we accept any signature
                     if (!PublicKeyExists())
                     {
                         result = ValidationResult.Unchecked;
@@ -115,7 +115,7 @@ namespace NetSparkle
                     break;
 
                 case SecurityMode.Strict:
-                    // only accept if we have both
+                    // only accept if we have both a public key and a non-null signature
                     if (!PublicKeyExists() || string.IsNullOrEmpty(signature))
                     {
                         result = ValidationResult.Invalid;
@@ -124,8 +124,9 @@ namespace NetSparkle
                     break;
                 
                 case SecurityMode.Unsafe:
-                    // always accept anything.
-                    // but exit with unchecked if we have an signature
+                    // always accept anything
+                    // If we don't have a signature, make sure to note this as "Unchecked" since we
+                    // didn't end up checking anything
                     if (!PublicKeyExists() || string.IsNullOrEmpty(signature))
                     {
                         result = ValidationResult.Unchecked;
@@ -144,7 +145,7 @@ namespace NetSparkle
         /// </summary>
         /// <param name="signature">expected signature</param>
         /// <param name="stream">the stream of the binary</param>
-        /// <returns><c>true</c> if the signature matches the expected signature.</returns>
+        /// <returns>A <c>ValidationResult</c> that corresponds to the result of the DSA signature process</returns>
         public ValidationResult VerifyDSASignature(string signature, Stream stream)
         {
             ValidationResult res = ValidationResult.Invalid;
@@ -168,7 +169,7 @@ namespace NetSparkle
         /// </summary>
         /// <param name="signature">expected signature</param>
         /// <param name="binaryPath">the path to the binary</param>
-        /// <returns><c>true</c> if the signature matches the expected signature.</returns>
+        /// <returns>A <c>ValidationResult</c> that corresponds to the result of the DSA signature process</returns>
         public ValidationResult VerifyDSASignatureFile(string signature, string binaryPath)
         {
             var data = string.Empty;
@@ -183,7 +184,7 @@ namespace NetSparkle
         /// </summary>
         /// <param name="signature">expected signature</param>
         /// <param name="data">the data</param>
-        /// <returns><c>true</c> if the signature matches the expected signature.</returns>
+        /// <returns>A <c>ValidationResult</c> that corresponds to the result of the DSA signature process</returns>
         public ValidationResult VerifyDSASignatureOfString(string signature, string data)
         {
             // creating stream from string

--- a/NetSparkle/NetSparkle.cs
+++ b/NetSparkle/NetSparkle.cs
@@ -1729,7 +1729,7 @@ namespace NetSparkle
             {
                 DownloadCanceled?.Invoke(_downloadTempFileName);
                 LogWriter.PrintMessage("Download was canceled");
-                string errorMessage = "Download cancelled";
+                string errorMessage = "Download canceled";
                 if (shouldShowUIItems && ProgressWindow != null && !ProgressWindow.DisplayErrorMessage(errorMessage))
                 {
                     UIFactory.ShowDownloadErrorMessage(errorMessage, _appCastUrl, _applicationIcon);
@@ -1760,7 +1760,7 @@ namespace NetSparkle
                 }
             }
 
-            bool isSignatureInvalid = validationRes == ValidationResult.Invalid;
+            bool isSignatureInvalid = validationRes == ValidationResult.Invalid; // if Unchecked, we accept download as valid
             if (shouldShowUIItems)
             {
                 ProgressWindow?.FinishedDownloadingFile(!isSignatureInvalid);

--- a/NetSparkle/NetSparkle.cs
+++ b/NetSparkle/NetSparkle.cs
@@ -1756,11 +1756,7 @@ namespace NetSparkle
                     }
 
                     // check the DSA signature
-                    string dsaSignature = _itemBeingDownloaded?.DownloadDSASignature;
-                    if (dsaSignature != null)
-                    {
-                        validationRes = DSAChecker.VerifyDSASignatureFile(dsaSignature, _downloadTempFileName);
-                    }
+                    validationRes = DSAChecker.VerifyDSASignatureFile(_itemBeingDownloaded?.DownloadDSASignature, _downloadTempFileName);
                 }
             }
 


### PR DESCRIPTION
since we'll bypass correct handling of security modes Unsafe and
UseIfPossible. This results in ValidationResult.Invalid instead of
ValidationResult.Unchecked.