### PR TITLE
Update file size check

### DIFF
--- a/NetSparkle/NetSparkle.cs
+++ b/NetSparkle/NetSparkle.cs
@@ -1020,8 +1020,9 @@ namespace NetSparkle
             bool needsToDownload = true;
             if (File.Exists(_downloadTempFileName))
             {
+                var fileInfo = new FileInfo(_downloadTempFileName);
                 ValidationResult result = DSAChecker.VerifyDSASignatureFile(item.DownloadDSASignature, _downloadTempFileName);
-                if (result == ValidationResult.Valid || result == ValidationResult.Unchecked)
+                if ((result == ValidationResult.Valid || result == ValidationResult.Unchecked) && fileInfo.Length == item.UpdateSize)
                 {
                     LogWriter.PrintMessage("File is already downloaded");
                     // We already have the file! Don't redownload it!

--- a/NetSparkle/NetSparkle.cs
+++ b/NetSparkle/NetSparkle.cs
@@ -1020,9 +1020,8 @@ namespace NetSparkle
             bool needsToDownload = true;
             if (File.Exists(_downloadTempFileName))
             {
-                var fileInfo = new FileInfo(_downloadTempFileName);
                 ValidationResult result = DSAChecker.VerifyDSASignatureFile(item.DownloadDSASignature, _downloadTempFileName);
-                if ((result == ValidationResult.Valid || result == ValidationResult.Unchecked) && fileInfo.Length == item.UpdateSize)
+                if (result == ValidationResult.Valid || result == ValidationResult.Unchecked)
                 {
                     LogWriter.PrintMessage("File is already downloaded");
                     // We already have the file! Don't redownload it!

--- a/NetSparkle/NetSparkle.cs
+++ b/NetSparkle/NetSparkle.cs
@@ -984,17 +984,25 @@ namespace NetSparkle
         {
             if (item != null && item.DownloadLink != null)
             {
-                string[] segments = item.DownloadLink.Split('/');
-                if (segments.Count() > 0)
+                string filename = string.Empty;
+
+                try
                 {
-                    string fileName = segments[segments.Length - 1];
-                    bool isTmpDownloadFilePathSet = TmpDownloadFilePath != null && TmpDownloadFilePath != "";
-                    string tmpPath = isTmpDownloadFilePathSet ? TmpDownloadFilePath : Path.GetTempPath();
-                    if (isTmpDownloadFilePathSet && !File.Exists(tmpPath))
-                    {
-                        Directory.CreateDirectory(tmpPath);
-                    }
-                    return Path.Combine(tmpPath, fileName);
+                    filename = Path.GetFileName(new Uri(item.DownloadLink).LocalPath);
+                }
+                catch (UriFormatException)
+                {
+                    // ignore
+                }
+
+                if (!string.IsNullOrEmpty(filename))
+                {
+                    string tmpPath = string.IsNullOrEmpty(TmpDownloadFilePath) ? Path.GetTempPath() : TmpDownloadFilePath;
+
+                    // Creates all directories and subdirectories in the specific path unless they already exist.
+                    Directory.CreateDirectory(tmpPath);
+
+                    return Path.Combine(tmpPath, filename);
                 }
             }
             return null;
@@ -1021,7 +1029,7 @@ namespace NetSparkle
             if (File.Exists(_downloadTempFileName))
             {
                 ValidationResult result = DSAChecker.VerifyDSASignatureFile(item.DownloadDSASignature, _downloadTempFileName);
-                if (result == ValidationResult.Valid || result == ValidationResult.Unchecked)
+                if (result == ValidationResult.Valid)
                 {
                     LogWriter.PrintMessage("File is already downloaded");
                     // We already have the file! Don't redownload it!
@@ -1035,10 +1043,10 @@ namespace NetSparkle
                 }
                 else if (!_hasAttemptedFileRedownload)
                 {
-                    // File is downloaded, but is corrupt or was stopped in the middle or something else happened.
+                    // The file exists but it either has a bad DSA signature or SecurityMode is set to Unsafe.
                     // Redownload it!
                     _hasAttemptedFileRedownload = true;
-                    LogWriter.PrintMessage("File is corrupt; deleting file and redownloading...");
+                    LogWriter.PrintMessage("File is corrupt or DSA signature is Unchecked; deleting file and redownloading...");
                     try
                     {
                         File.Delete(_downloadTempFileName);

--- a/NetSparkle/NetSparkle.cs
+++ b/NetSparkle/NetSparkle.cs
@@ -1780,6 +1780,7 @@ namespace NetSparkle
             if (e.Cancelled)
             {
                 DownloadCanceled?.Invoke(_downloadTempFileName);
+                _hasAttemptedFileRedownload = false;
                 if (File.Exists(_downloadTempFileName))
                 {
                     File.Delete(_downloadTempFileName);


### PR DESCRIPTION
When NetSparkle's security mode is configured as `SecurityMode.Unsafe`, and when the app is terminated unexpectedly (e.g. the process is killed via task manager), on the next application run, NetSparkle thinks the update file already exists and tries to run it. That said, when Unsafe mode is used, NetSparkle never checks the file size, thus there's a chance it will run the update file which is corrupted. This PR fixes the edge case.

That happens only when Unsafe mode is used, as far as I can say. When its Strict, NetSparkle will check the DSA signature and will fail if the file wasn't downloaded correctly.

Alternatively, NetSparkle could download the update to a temp file (randomly generated one), and rename it when it is successful.