### PR TITLE
Added pubDate handling for MS AppCenter Sparkle date format which end…

### DIFF
--- a/NetSparkle/AppCast.cs
+++ b/NetSparkle/AppCast.cs
@@ -279,9 +279,20 @@ namespace NetSparkle
                                 {
                                     currentItem.PublicationDate = DateTime.ParseExact(dt, "ddd, dd MMM yyyy HH:mm:ss zzz", System.Globalization.CultureInfo.InvariantCulture);
                                 }
-                                catch (FormatException ex)
+                                catch (FormatException)
                                 {
-                                    _logWriter.PrintMessage("Cannot parse item datetime {0} with message {1}", dt, ex.Message);
+                                    // Check for MS AppCenter Sparkle date format which ends with GMT
+                                    // e.g. "Sat, 26 Oct 2019 22:05:11 GMT"
+
+                                    try
+                                    {
+                                        currentItem.PublicationDate = DateTime.ParseExact(dt, "ddd, dd MMM yyyy HH:mm:ss Z", System.Globalization.CultureInfo.InvariantCulture);
+                                    }
+                                    catch (FormatException ex)
+                                    {
+                                        _logWriter.PrintMessage("Cannot parse item datetime {0} with message {1}", dt, ex.Message);
+                                    }
+
                                 }
                             }
                             break;
@@ -310,7 +321,8 @@ namespace NetSparkle
             Version installed = new Version(_config.InstalledVersion);
             var signatureNeeded = _dsaChecker.SignatureNeeded();
 
-            return _items.Where((item) => {
+            return _items.Where((item) =>
+            {
                 // don't allow non-windows updates
                 if (!item.IsWindowsUpdate)
                     return false;

--- a/NetSparkle/NetSparkle.csproj
+++ b/NetSparkle/NetSparkle.csproj
@@ -115,6 +115,7 @@
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>


### PR DESCRIPTION
The date format that Microsoft use for HockeyApp and now AppCenter is slightly different and ends with "GMT" instead of a numeric offset e.g. "Sat, 26 Oct 2019 22:05:11 GMT"

This causes an exception with the existing dateTime Parsing.

This PR adds a secondary check to check using the Z suffix.

An example AppCenter sparkle App feed is https://api.appcenter.ms/v0.1/public/sparkle/apps/c27e6512-ceae-4665-82c5-c0d7f6a27f30

