### PR TITLE
Clarified in Sample Application that the calling application must call ShowUpdateNeededUi 

### DIFF
--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.16.6")]
-[assembly: AssemblyFileVersion("0.16.6")]
+[assembly: AssemblyVersion("0.16.7")]
+[assembly: AssemblyFileVersion("0.16.7")]

--- a/NetSparkleTestAppWPF/MainWindow.xaml.cs
+++ b/NetSparkleTestAppWPF/MainWindow.xaml.cs
@@ -12,7 +12,7 @@ namespace NetSparkle.TestAppWPF
         private Sparkle _sparkle;
 
         public MainWindow()
-        {           
+        {
             InitializeComponent();
 
             // remove the netsparkle key from registry 
@@ -25,9 +25,16 @@ namespace NetSparkle.TestAppWPF
             // set icon in project properties!
             string manifestModuleName = System.Reflection.Assembly.GetEntryAssembly().ManifestModule.FullyQualifiedName;
             var icon = System.Drawing.Icon.ExtractAssociatedIcon(manifestModuleName);
-            _sparkle = new Sparkle("https://deadpikle.github.io/NetSparkle/files/sample-app/appcast.xml", icon); //, "NetSparkleTestApp.exe");
+            //_sparkle = new Sparkle("https://deadpikle.github.io/NetSparkle/files/sample-app/appcast.xml", icon); //, "NetSparkleTestApp.exe");
+
+            _sparkle = new Sparkle(
+                "https://api.appcenter.ms/v0.1/public/sparkle/apps/c27e6512-ceae-4665-82c5-c0d7f6a27f30",
+                icon,
+                NetSparkle.Enums.SecurityMode.Unsafe); //, "NetSparkleTestApp.exe");
+
+
             // TLS 1.2 required by GitHub (https://developer.github.com/changes/2018-02-01-weak-crypto-removal-notice/)
-            _sparkle.SecurityProtocolType = System.Net.SecurityProtocolType.Tls12; 
+            _sparkle.SecurityProtocolType = System.Net.SecurityProtocolType.Tls12;
             _sparkle.StartLoop(true, true);
         }
 

--- a/SampleApplication/Form1.Designer.cs
+++ b/SampleApplication/Form1.Designer.cs
@@ -32,8 +32,8 @@ namespace SampleApplication
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
             this.checkForUpdatesTimer = new System.Windows.Forms.Timer(this.components);
             this.notifyIcon1 = new System.Windows.Forms.NotifyIcon(this.components);
-            this.button1 = new System.Windows.Forms.Button();
-            this.button2 = new System.Windows.Forms.Button();
+            this.AppBackgroundCheckButton = new System.Windows.Forms.Button();
+            this.ExplicitUserRequestCheckButton = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // checkForUpdatesTimer
@@ -48,37 +48,34 @@ namespace SampleApplication
             this.notifyIcon1.Text = "notifyIcon1";
             this.notifyIcon1.Visible = true;
             // 
-            // button1
+            // AppBackgroundCheckButton
             // 
-            this.button1.Location = new System.Drawing.Point(24, 71);
-            this.button1.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(424, 44);
-            this.button1.TabIndex = 0;
-            this.button1.Text = "App Background Check";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
+            this.AppBackgroundCheckButton.Location = new System.Drawing.Point(12, 37);
+            this.AppBackgroundCheckButton.Name = "AppBackgroundCheckButton";
+            this.AppBackgroundCheckButton.Size = new System.Drawing.Size(212, 23);
+            this.AppBackgroundCheckButton.TabIndex = 0;
+            this.AppBackgroundCheckButton.Text = "App Background Check";
+            this.AppBackgroundCheckButton.UseVisualStyleBackColor = true;
+            this.AppBackgroundCheckButton.Click += new System.EventHandler(this.AppBackgroundCheckButton_Click);
             // 
-            // button2
+            // ExplicitUserRequestCheckButton
             // 
-            this.button2.Location = new System.Drawing.Point(24, 154);
-            this.button2.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
-            this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(424, 44);
-            this.button2.TabIndex = 1;
-            this.button2.Text = "Explicit User Request To Check ";
-            this.button2.UseVisualStyleBackColor = true;
-            this.button2.Click += new System.EventHandler(this.button2_Click);
+            this.ExplicitUserRequestCheckButton.Location = new System.Drawing.Point(12, 80);
+            this.ExplicitUserRequestCheckButton.Name = "ExplicitUserRequestCheckButton";
+            this.ExplicitUserRequestCheckButton.Size = new System.Drawing.Size(212, 23);
+            this.ExplicitUserRequestCheckButton.TabIndex = 1;
+            this.ExplicitUserRequestCheckButton.Text = "Explicit User Request To Check ";
+            this.ExplicitUserRequestCheckButton.UseVisualStyleBackColor = true;
+            this.ExplicitUserRequestCheckButton.Click += new System.EventHandler(this.ExplicitUserRequestCheckButton_Click);
             // 
             // Form1
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(496, 296);
-            this.Controls.Add(this.button2);
-            this.Controls.Add(this.button1);
+            this.ClientSize = new System.Drawing.Size(248, 154);
+            this.Controls.Add(this.ExplicitUserRequestCheckButton);
+            this.Controls.Add(this.AppBackgroundCheckButton);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
             this.Name = "Form1";
             this.Text = "Form1";
             this.ResumeLayout(false);
@@ -89,8 +86,8 @@ namespace SampleApplication
 
         private System.Windows.Forms.Timer checkForUpdatesTimer;
         private System.Windows.Forms.NotifyIcon notifyIcon1;
-        private System.Windows.Forms.Button button1;
-        private System.Windows.Forms.Button button2;
+        private System.Windows.Forms.Button AppBackgroundCheckButton;
+        private System.Windows.Forms.Button ExplicitUserRequestCheckButton;
     }
 }
 

--- a/SampleApplication/Form1.cs
+++ b/SampleApplication/Form1.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Reflection;
 using System.Windows.Forms;
 using NetSparkle;
+using NetSparkle.Enums;
 
 namespace SampleApplication
 {
@@ -31,12 +32,19 @@ namespace SampleApplication
             Application.Exit();
         }
 
-        private void button1_Click(object sender, EventArgs e)
+        private async void AppBackgroundCheckButton_Click(object sender, EventArgs e)
         {
-            _sparkleUpdateDetector.CheckForUpdatesQuietly();
+            // Manually check for updates, this will not show a ui
+            var result = await _sparkleUpdateDetector.CheckForUpdatesQuietly();
+            if (result.Status == UpdateStatus.UpdateAvailable)
+            {
+                // if update(s) are found, then we have to trigger the UI to show it gracefully
+                _sparkleUpdateDetector.ShowUpdateNeededUI();
+            }
+
         }
 
-        private void button2_Click(object sender, EventArgs e)
+        private void ExplicitUserRequestCheckButton_Click(object sender, EventArgs e)
         {
             _sparkleUpdateDetector.CheckForUpdatesAtUserRequest();
         }


### PR DESCRIPTION
Very minor change: I've updated the Sample Application to show that the calling application must explicitly call ShowUpdateNeededUi after CheckForUpdatesQuietly if it has returned that updates are available.